### PR TITLE
installation: fix invenio_base imports

### DIFF
--- a/.travis.invenio.cfg
+++ b/.travis.invenio.cfg
@@ -31,5 +31,5 @@ ASSETS_AUTO_BUILD = False
 
 PACKAGES = [
     'invenio_upgrader',
-    'invenio.base',
+    'invenio_base',
 ]

--- a/invenio_upgrader/__init__.py
+++ b/invenio_upgrader/__init__.py
@@ -24,7 +24,7 @@ Usage (via ``inveniomanage``).
 .. code-block:: console
 
     $ inveniomanage upgrader create recipe -p invenio_search
-    $ inveniomanage upgrader create release -r invenio -p invenio.base
+    $ inveniomanage upgrader create release -r invenio -p invenio_base
     $ inveniomanage upgrader show applied
     $ inveniomanage upgrader show pending
     $ inveniomanage upgrader check
@@ -74,8 +74,8 @@ the graph and will refuse to run any upgrades until the cycles have been
 broken.
 """
 
-from invenio.base import signals
-from invenio.base.scripts.database import create, recreate
+from invenio_base import signals
+from invenio_base.scripts.database import create, recreate
 
 
 def populate_existing_upgrades(sender, yes_i_know=False, drop=True, **kwargs):

--- a/invenio_upgrader/manage.py
+++ b/invenio_upgrader/manage.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2013, 2014 CERN.
+# Copyright (C) 2013, 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -112,7 +112,7 @@ def recipe(package, repository=None, depends_on=None, release=False,
 
 
 def main():
-    from invenio.base.factory import create_app
+    from invenio_base.factory import create_app
     app = create_app()
     manager.app = app
     manager.run()

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -27,3 +27,5 @@
 #
 #     -e git+git://github.com/mitsuhiko/werkzeug.git#egg=Werkzeug
 #     -e git+git://github.com/mitsuhiko/jinja2.git#egg=Jinja2
+
+-e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ requirements = [
     'alembic>=0.6.6,<0.7',
     'Flask>=0.10.1',
     'six>=1.7.2',
+    'invenio-base>=0.2.1',
 ]
 
 test_requirements = [
@@ -50,6 +51,7 @@ test_requirements = [
 
 
 class PyTest(TestCommand):
+
     """PyTest Test."""
 
     user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]


### PR DESCRIPTION
- FIX Adds missing `invenio_base` dependency and amends past
  upgrade recipes following its separation into standalone package.

Signed-off-by: Sami Hiltunen sami.mikael.hiltunen@cern.ch
