### PR TITLE
tests: fix incompatibility with pytest>=2.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ python:
 
 before_install:
   - "travis_retry pip install --upgrade pip"
-  - "travis_retry pip install mock twine wheel coveralls"
+  - "travis_retry pip install check-manifest mock twine wheel coveralls"
   - "python requirements.py --extras=$REXTRAS --level=min > .travis-lowest-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=pypi > .travis-release-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=dev > .travis-devel-requirements.txt"
@@ -65,6 +65,7 @@ before_script:
   - "inveniomanage database create --quiet"
 
 script:
+  - "check-manifest --ignore .travis-\\*-requirements.txt"
   - "sphinx-build -qnN docs docs/_build/html"
   - "python setup.py test"
 

--- a/invenio_upgrader/commands.py
+++ b/invenio_upgrader/commands.py
@@ -55,7 +55,7 @@ UPGRADE_TEMPLATE = """# -*- coding: utf-8 -*-
 
 import warnings
 
-from invenio.ext.sqlalchemy import db
+from invenio_ext.sqlalchemy import db
 from invenio_upgrader.api import op
 from invenio.utils.text import wait_for_user
 
@@ -345,7 +345,7 @@ def _write_template(upgrade_file, depends_on, repository, auto=False):
     """Write template to upgrade file."""
     if auto:
         # Ensure all models are loaded
-        from invenio.ext.sqlalchemy import models
+        from invenio_ext.sqlalchemy import models
         list(models)
         template_args = produce_upgrade_operations()
         operations_str = template_args['upgrades']

--- a/invenio_upgrader/commands.py
+++ b/invenio_upgrader/commands.py
@@ -57,7 +57,7 @@ import warnings
 
 from invenio_ext.sqlalchemy import db
 from invenio_upgrader.api import op
-from invenio.utils.text import wait_for_user
+from invenio_utils.text import wait_for_user
 
 from sqlalchemy import *
 
@@ -133,7 +133,7 @@ def cmd_upgrade_check(upgrader=None):
 def cmd_upgrade(upgrader=None):
     """Command for applying upgrades."""
     from flask import current_app
-    from invenio.utils.text import wrap_text_in_a_box, wait_for_user
+    from invenio_utils.text import wrap_text_in_a_box, wait_for_user
 
     logfilename = os.path.join(current_app.config['CFG_LOGDIR'],
                                'invenio_upgrader.log')

--- a/invenio_upgrader/engine.py
+++ b/invenio_upgrader/engine.py
@@ -349,7 +349,7 @@ class InvenioUpgrader(object):
             returned.
         """
         from invenio_ext.registry import ModuleAutoDiscoverySubRegistry
-        from invenio.utils.autodiscovery import create_enhanced_plugin_builder
+        from invenio_utils.autodiscovery import create_enhanced_plugin_builder
 
         if remove_applied:
             self.load_history()

--- a/invenio_upgrader/engine.py
+++ b/invenio_upgrader/engine.py
@@ -31,7 +31,7 @@ from flask import current_app
 from flask_registry import ImportPathRegistry, RegistryProxy
 from sqlalchemy import desc
 
-from invenio.ext.sqlalchemy import db
+from invenio_ext.sqlalchemy import db
 
 from .checks import post_check_bibsched
 from .logging import InvenioUpgraderLogFormatter
@@ -348,7 +348,7 @@ class InvenioUpgrader(object):
             be included, if False the entire upgrade graph will be
             returned.
         """
-        from invenio.ext.registry import ModuleAutoDiscoverySubRegistry
+        from invenio_ext.registry import ModuleAutoDiscoverySubRegistry
         from invenio.utils.autodiscovery import create_enhanced_plugin_builder
 
         if remove_applied:

--- a/invenio_upgrader/manage.py
+++ b/invenio_upgrader/manage.py
@@ -17,7 +17,7 @@
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
-from invenio.ext.script import Manager
+from invenio_ext.script import Manager
 
 manager = Manager(usage="Perform upgrade engine operations.")
 

--- a/invenio_upgrader/models.py
+++ b/invenio_upgrader/models.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2012, 2014 CERN.
+# Copyright (C) 2012, 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -22,7 +22,7 @@ Upgrade engine database model for keeping log of which upgrades have been
 applied to to a given database.
 """
 
-from invenio.ext.sqlalchemy import db
+from invenio_ext.sqlalchemy import db
 
 
 class Upgrade(db.Model):

--- a/invenio_upgrader/operations.py
+++ b/invenio_upgrader/operations.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2012, 2013 CERN.
+# Copyright (C) 2012, 2013, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -28,7 +28,7 @@ from alembic.environment import EnvironmentContext
 from alembic.operations import Operations
 from alembic.autogenerate.api import _produce_migration_diffs
 from alembic.config import Config
-from invenio.ext.sqlalchemy import db
+from invenio_ext.sqlalchemy import db
 
 
 op = LocalProxy(lambda: create_operations())

--- a/invenio_upgrader/upgrades/invenio_2012_10_31_WebAuthorProfile_bibformat_dependency_update.py
+++ b/invenio_upgrader/upgrades/invenio_2012_10_31_WebAuthorProfile_bibformat_dependency_update.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2012 CERN.
+# Copyright (C) 2012, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,7 +19,7 @@
 
 import warnings
 from invenio.legacy.dbquery import run_sql
-from invenio.utils.text import wait_for_user
+from invenio_utils.text import wait_for_user
 
 depends_on = ['invenio_release_1_1_0']
 

--- a/invenio_upgrader/upgrades/invenio_2012_10_31_tablesorter_location.py
+++ b/invenio_upgrader/upgrades/invenio_2012_10_31_tablesorter_location.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2012 CERN.
+# Copyright (C) 2012, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,7 +19,7 @@
 
 import warnings
 from invenio.legacy.dbquery import run_sql
-from invenio.utils.text import wait_for_user
+from invenio_utils.text import wait_for_user
 
 import os
 from invenio.config import CFG_WEBDIR

--- a/invenio_upgrader/upgrades/invenio_2012_11_04_circulation_and_linkback_updates.py
+++ b/invenio_upgrader/upgrades/invenio_2012_11_04_circulation_and_linkback_updates.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2012 CERN.
+# Copyright (C) 2012, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,7 +19,7 @@
 
 import warnings
 from invenio.legacy.dbquery import run_sql
-from invenio.utils.text import wait_for_user
+from invenio_utils.text import wait_for_user
 
 depends_on = ['invenio_release_1_1_0']
 

--- a/invenio_upgrader/upgrades/invenio_2012_11_07_xtrjob_last_recid.py
+++ b/invenio_upgrader/upgrades/invenio_2012_11_07_xtrjob_last_recid.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2012 CERN.
+# Copyright (C) 2012, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,7 +19,7 @@
 
 import warnings
 from invenio.legacy.dbquery import run_sql
-from invenio.utils.text import wait_for_user
+from invenio_utils.text import wait_for_user
 
 depends_on = ['invenio_release_1_1_0']
 

--- a/invenio_upgrader/upgrades/invenio_2012_12_05_oaiHARVEST_arguments_blob.py
+++ b/invenio_upgrader/upgrades/invenio_2012_12_05_oaiHARVEST_arguments_blob.py
@@ -20,7 +20,7 @@
 """Upgrade recipe."""
 
 from invenio.legacy.dbquery import run_sql
-from invenio.utils.serializers import deserialize_via_marshal, \
+from invenio_utils.serializers import deserialize_via_marshal, \
     serialize_via_marshal
 
 

--- a/invenio_upgrader/upgrades/invenio_2013_02_01_oaiREPOSITORY_last_updated.py
+++ b/invenio_upgrader/upgrades/invenio_2013_02_01_oaiREPOSITORY_last_updated.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2013 CERN.
+# Copyright (C) 2013, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,7 +19,7 @@
 
 import warnings
 from invenio.legacy.dbquery import run_sql
-from invenio.utils.text import wait_for_user
+from invenio_utils.text import wait_for_user
 
 depends_on = ['invenio_release_1_1_0']
 

--- a/invenio_upgrader/upgrades/invenio_2013_03_07_crcILLREQUEST_overdue_letter.py
+++ b/invenio_upgrader/upgrades/invenio_2013_03_07_crcILLREQUEST_overdue_letter.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2012 CERN.
+# Copyright (C) 2012, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,7 +19,7 @@
 
 import warnings
 from invenio.legacy.dbquery import run_sql
-from invenio.utils.text import wait_for_user
+from invenio_utils.text import wait_for_user
 
 depends_on = ['invenio_release_1_1_0']
 

--- a/invenio_upgrader/upgrades/invenio_2013_03_18_aidPERSONIDDATA_last_updated.py
+++ b/invenio_upgrader/upgrades/invenio_2013_03_18_aidPERSONIDDATA_last_updated.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2013 CERN.
+# Copyright (C) 2013, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,7 +19,7 @@
 
 import warnings
 from invenio.legacy.dbquery import run_sql
-from invenio.utils.text import wait_for_user
+from invenio_utils.text import wait_for_user
 
 depends_on = ['invenio_release_1_1_0']
 

--- a/invenio_upgrader/upgrades/invenio_2013_03_18_wapCACHE_object_value_longblob.py
+++ b/invenio_upgrader/upgrades/invenio_2013_03_18_wapCACHE_object_value_longblob.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2013 CERN.
+# Copyright (C) 2013, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,7 +19,7 @@
 
 import warnings
 from invenio.legacy.dbquery import run_sql
-from invenio.utils.text import wait_for_user
+from invenio_utils.text import wait_for_user
 
 depends_on = ['invenio_release_1_1_0']
 

--- a/invenio_upgrader/upgrades/invenio_2013_09_02_new_bibARXIVPDF.py
+++ b/invenio_upgrader/upgrades/invenio_2013_09_02_new_bibARXIVPDF.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2013 CERN.
+# Copyright (C) 2013, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,7 +19,7 @@
 
 import warnings
 from invenio.legacy.dbquery import run_sql
-from invenio.utils.text import wait_for_user
+from invenio_utils.text import wait_for_user
 
 depends_on = ['invenio_release_1_1_0']
 

--- a/invenio_upgrader/upgrades/invenio_2013_10_11_bibHOLDINGPEN_longblob.py
+++ b/invenio_upgrader/upgrades/invenio_2013_10_11_bibHOLDINGPEN_longblob.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2013 CERN.
+# Copyright (C) 2013, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -69,7 +69,7 @@ def pre_upgrade():
                          SELECT DISTINCT(changeset_id) FROM bibHOLDINGPEN
                          WHERE LENGTH(changeset_xml) =  65535""" % len(res))
 
-        from invenio.utils.text import wait_for_user
+        from invenio_utils.text import wait_for_user
         try:
             wait_for_user(
                 "\nThis upgrade will delete all the corrupted entries. A backup table bibHOLDINGPEN_backup will be created.\n")

--- a/invenio_upgrader/upgrades/invenio_2013_12_04_seqSTORE_larger_value.py
+++ b/invenio_upgrader/upgrades/invenio_2013_12_04_seqSTORE_larger_value.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2013 CERN.
+# Copyright (C) 2013, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,7 +19,7 @@
 
 import warnings
 from invenio.legacy.dbquery import run_sql
-from invenio.utils.text import wait_for_user
+from invenio_utils.text import wait_for_user
 
 depends_on = ['invenio_release_1_1_0']
 

--- a/invenio_upgrader/upgrades/invenio_2014_06_02_oaiHARVEST_arguments_cfg_namechange.py
+++ b/invenio_upgrader/upgrades/invenio_2014_06_02_oaiHARVEST_arguments_cfg_namechange.py
@@ -20,7 +20,7 @@
 """Upgrade recipe."""
 
 from invenio.legacy.dbquery import run_sql
-from invenio.utils.serializers import deserialize_via_marshal, \
+from invenio_utils.serializers import deserialize_via_marshal, \
     serialize_via_marshal
 
 depends_on = ['invenio_release_1_1_0']

--- a/invenio_upgrader/upgrades/invenio_release_1_1_0.py
+++ b/invenio_upgrader/upgrades/invenio_release_1_1_0.py
@@ -1,7 +1,7 @@
 #-*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2008, 2009, 2010, 2011, 2012 CERN.
+# Copyright (C) 2008, 2009, 2010, 2011, 2012, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -551,7 +551,7 @@ def pre_upgrade():
                       " between 1.0.x and 1.1.0")
 
         # Run import here, since we are on 1.0-1.1 we know the import will work
-        from invenio.utils.text import wait_for_user
+        from invenio_utils.text import wait_for_user
         try:
             wait_for_user("\nUPGRADING TO 1.1.0 FROM A DEVELOPMENT VERSION"
                           " WILL LEAD TO MANY WARNINGS! Please thoroughly"

--- a/invenio_upgrader/upgrades/submit_2015_03_03_fix_models.py
+++ b/invenio_upgrader/upgrades/submit_2015_03_03_fix_models.py
@@ -21,7 +21,7 @@
 
 import warnings
 
-from invenio.ext.sqlalchemy import db
+from invenio_ext.sqlalchemy import db
 from invenio.legacy.dbquery import run_sql
 from invenio_upgrader.api import op
 

--- a/invenio_upgrader/upgrades/submit_2015_04_30_fix_models_sbmFORMATEXTENSION_sbmGFILERESULT.py
+++ b/invenio_upgrader/upgrades/submit_2015_04_30_fix_models_sbmFORMATEXTENSION_sbmGFILERESULT.py
@@ -21,7 +21,7 @@
 
 import warnings
 
-from invenio.ext.sqlalchemy import db
+from invenio_ext.sqlalchemy import db
 from invenio.legacy.dbquery import run_sql
 from invenio_upgrader.api import op
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -23,7 +23,7 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 [pytest]
-addopts = --clearcache --pep8 --ignore=docs --cov=invenio_upgrader --cov-report=term-missing
+addopts = --pep8 --ignore=docs --cov=invenio_upgrader --cov-report=term-missing
 pep8ignore =
     tests/* ALL
     invenio_upgrader/upgrades/* ALL

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -29,3 +29,4 @@
 #     -e git+git://github.com/mitsuhiko/jinja2.git#egg=Jinja2
 
 -e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base
+-e git+git://github.com/inveniosoftware/invenio-ext.git#egg=invenio-ext

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -30,3 +30,4 @@
 
 -e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base
 -e git+git://github.com/inveniosoftware/invenio-ext.git#egg=invenio-ext
+-e git+git://github.com/inveniosoftware/invenio-utils.git#egg=invenio-utils

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -21,13 +21,9 @@
 # In applying this license, CERN does not
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
-#
-# TODO: Add development versions of some important dependencies here to get a
-#       warning when there are breaking upstream changes, e.g.:
-#
-#     -e git+git://github.com/mitsuhiko/werkzeug.git#egg=Werkzeug
-#     -e git+git://github.com/mitsuhiko/jinja2.git#egg=Jinja2
 
 -e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base
 -e git+git://github.com/inveniosoftware/invenio-ext.git#egg=invenio-ext
+-e git+git://github.com/inveniosoftware/invenio-testing.git#egg=invenio-testing
 -e git+git://github.com/inveniosoftware/invenio-utils.git#egg=invenio-utils
+

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ requirements = [
     'six>=1.7.2',
     'invenio-base>=0.2.1',
     'invenio-ext>=0.1.0',
+    'invenio-utils>=0.1.0',
 ]
 
 test_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -43,10 +43,10 @@ requirements = [
 test_requirements = [
     'unittest2>=1.1.0',
     'Flask_Testing>=0.4.1',
-    'pytest>=2.7.0',
-    'pytest-cov>=1.8.0',
+    'pytest>=2.8.0',
+    'pytest-cov>=2.1.0',
     'pytest-pep8>=1.0.6',
-    'coverage>=3.7.1',
+    'coverage>=4.0.0',
 ]
 
 
@@ -78,9 +78,6 @@ class PyTest(TestCommand):
         """Run tests."""
         # import here, cause outside the eggs aren't loaded
         import pytest
-        import _pytest.config
-        pm = _pytest.config.get_plugin_manager()
-        pm.consider_setuptools_entrypoints()
         errno = pytest.main(self.pytest_args)
         sys.exit(errno)
 

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ requirements = [
     'Flask>=0.10.1',
     'six>=1.7.2',
     'invenio-base>=0.2.1',
+    'invenio-ext>=0.1.0',
 ]
 
 test_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ test_requirements = [
     'pytest-cov>=2.1.0',
     'pytest-pep8>=1.0.6',
     'coverage>=4.0.0',
+    'invenio-testing>=0.1.0',
 ]
 
 

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -21,10 +21,9 @@
 
 from __future__ import print_function
 
-import sys
-
 from invenio_base.utils import run_py_func
-from invenio.testsuite import InvenioTestCase
+
+from invenio_testing import InvenioTestCase
 
 
 class UpgraderManageTest(InvenioTestCase):

--- a/tests/test_upgrader.py
+++ b/tests/test_upgrader.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2012, 2013 CERN.
+# Copyright (C) 2012, 2013, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,17 +19,20 @@
 
 """ Test unit for the miscutil/lib/inveniocfg_upgrader module. """
 
-
-from datetime import date
 import os
 import os.path
+
 import shutil
+
 import sys
+
 import tempfile
 
-import six
+from datetime import date
 
-from invenio.testsuite import make_test_suite, run_test_suite, InvenioTestCase
+from invenio_testing import InvenioTestCase
+
+import six
 
 
 def dictify(ls, value=None):
@@ -183,6 +186,7 @@ class TestInvenioUpgraderOrdering(InvenioTestCase):
 
 
 class TestInvenioUpgraderRecipe(InvenioTestCase):
+
     def setUp(self):
         """
         Setup a test python package, to test upgrade recipe creation.
@@ -335,12 +339,3 @@ class TestInvenioUpgraderRecipe(InvenioTestCase):
         for u in upgrades:
             if u['id'] == 'invenio_release_x_y_z':
                 assert len(u['depends_on']) == 2
-
-
-TEST_SUITE = make_test_suite(
-    TestInvenioUpgraderOrdering,
-    TestInvenioUpgraderRecipe,
-)
-
-if __name__ == "__main__":
-    run_test_suite(TEST_SUITE)


### PR DESCRIPTION
- FIX Removes calls to PluginManager
  consider_setuptools_entrypoints() removed in PyTest 2.8.0.

Signed-off-by: Sami Hiltunen sami.mikael.hiltunen@cern.ch
